### PR TITLE
Change Windows paths to webby paths

### DIFF
--- a/build_doc.js
+++ b/build_doc.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
     p = require('path'),
+    { posix } = require('path'),
     mime = require('mime'),
     extend = require('xok');
 
@@ -123,7 +124,8 @@ module.exports = function (ddoc_dir, opts) {
   }
   function addAttsFromDir(atts, doc_dir, dir, pre) {
     forEachEntry(doc_dir, dir, function (file, type, rel_path, abs_path) {
-      var key = p.join(pre,file);
+      // use posix variant of node's path utility for URL construction
+      var key = posix.join(pre,file);
       if (type.isDirectory()) addAttsFromDir(atts, doc_dir, rel_path, key);
       else atts[key] = {
         content_type: mime.getType(file),


### PR DESCRIPTION
Thank you for building putdoc! It's nice to have something...less antique...to be using with ye olde CouchApp code I have laying around. 😄 

This replaces Windows path's `\\` with `/` when generating attachment URLs.